### PR TITLE
Support configuration cache

### DIFF
--- a/src/main/kotlin/eu/cloudnetservice/gradle/juppiter/GenerateModuleJson.kt
+++ b/src/main/kotlin/eu/cloudnetservice/gradle/juppiter/GenerateModuleJson.kt
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import org.gradle.api.DefaultTask
-import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
@@ -30,13 +29,9 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
-import javax.inject.Inject
 
 @CacheableTask
 abstract class GenerateModuleJson : DefaultTask() {
-  @get:Inject
-  abstract val repositoryHandler: RepositoryHandler
-
   @get:Input
   abstract val fileName: Property<String>
 
@@ -60,7 +55,6 @@ abstract class GenerateModuleJson : DefaultTask() {
 
     // generate the output data
     val moduleConfiguration = moduleConfiguration.get()
-    moduleConfiguration.resolveRepositories(repositoryHandler)
 
     // write the output file
     mapper.writeValue(outputDirectory.file(fileName).get().asFile, moduleConfiguration)

--- a/src/main/kotlin/eu/cloudnetservice/gradle/juppiter/JuppiterPlugin.kt
+++ b/src/main/kotlin/eu/cloudnetservice/gradle/juppiter/JuppiterPlugin.kt
@@ -44,6 +44,9 @@ class JuppiterPlugin : Plugin<Project> {
           moduleConfiguration.convention(
             provider {
               moduleExtension.setDefaults(this@run, libraries, moduleDependencies)
+
+              // This provider is lazy, so it should be applied after project configuration
+              moduleExtension.resolveRepositories(project.repositories)
               moduleExtension
             },
           )


### PR DESCRIPTION
Main change in logic:
Moved resolveRepositories call out of task execution. Repositories are known after configuration is complete, so we can resolve them when the task asks for them.
Old behavior breaks the logic: Originally when the ModuleConfiguration is stored, there are no repositories known. The injected RepositoryHandler does not contain any repositories, because the configuration cache was used. So GenerateModuleJson fails because no repositories could be found.

While I was here, I also updated gradle and the publish plugin.
Also moved to toolchains (modifying the kotlinOptions in the task is deprecated)
(Maybe get renovate in here)